### PR TITLE
Lower-casing the letters in the hex hash output because:

### DIFF
--- a/src/main/java/gov/usgs/cida/simplehash/SimpleHash.java
+++ b/src/main/java/gov/usgs/cida/simplehash/SimpleHash.java
@@ -4,6 +4,7 @@ import javax.xml.bind.DatatypeConverter;
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
 
 /**
  * A vanilla Java solution for consistently hashing Strings to 
@@ -34,7 +35,7 @@ public class SimpleHash {
 		}
 		
 		byte[] hash = md.digest();
-		String encodedHash = DatatypeConverter.printHexBinary(hash);
+		String encodedHash = DatatypeConverter.printHexBinary(hash).toLowerCase(Locale.ENGLISH);
 		return encodedHash;
 	}
 	

--- a/src/test/java/gov/usgs/cida/simplehash/SimpleHashTest.java
+++ b/src/test/java/gov/usgs/cida/simplehash/SimpleHashTest.java
@@ -13,17 +13,17 @@ public class SimpleHashTest {
 	public void testKnownHashes() {
 		String plainText = "water";
 		String hashAlgorithm = "SHA-1";
-		String expResult = "6d5a45920a15adea049c8f22d569ff209625a43b".toUpperCase();
+		String expResult = "6d5a45920a15adea049c8f22d569ff209625a43b";
 		String result = SimpleHash.hash(plainText, hashAlgorithm);
 		assertEquals(expResult, result);
 		
 		hashAlgorithm = "MD5";
-		expResult = "9460370bb0ca1c98a779b1bcc6861c2c".toUpperCase();
+		expResult = "9460370bb0ca1c98a779b1bcc6861c2c";
 		result = SimpleHash.hash(plainText, hashAlgorithm);
 		assertEquals(expResult, result);
 		
 		hashAlgorithm = "SHA-256";
-		expResult = "0f4168490e38b8447e11ba4bd656aa11b925bd22af30bac464bc153fdb608501".toUpperCase();
+		expResult = "0f4168490e38b8447e11ba4bd656aa11b925bd22af30bac464bc153fdb608501";
 		result = SimpleHash.hash(plainText, hashAlgorithm);
 		assertEquals(expResult, result);
 	}


### PR DESCRIPTION
	- other tools seem to do it that way
	- some fonts make capital B look like an 8, or capital D look like a 0